### PR TITLE
🐛 로그인 페이지에서 애플 로그인 시 기존에 있던 사용자면 홈페이지로 이동 안되는 버그 수정

### DIFF
--- a/lib/presentation/pages/login/login_page.dart
+++ b/lib/presentation/pages/login/login_page.dart
@@ -131,10 +131,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                                                 .notifier)
                                         .getUserProfile(result);
                                     if (isRegistered) {
-                                      context.go('/onboarding1');
+                                      context.go('/home');
                                     } else {
                                       // TODO: 여기에 홈페이지로 이동 넣어야함
-                                      context.go('/onboarding2');
+                                      context.go('/onboarding1');
                                     }
                                   }
                                 },


### PR DESCRIPTION
로그인 페이지에서 애플 로그인 시 기존에 있던 사용자면 홈페이지로 이동 안되는 버그 수정 (온보딩 -> 온보딩 part 2로 이동되는 버그 수정)